### PR TITLE
Bug Fix in Transform Expression

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -223,9 +223,8 @@ class Expression:
                 if isinstance(cn, Expression):
                     new_child_node = cn.transform(
                         fun, *args, copy=False, **kwargs)
-                    if new_child_node is None:
-                        continue
-                    new_child_node.parent = new_node
+                    if new_child_node is not None:
+                        new_child_node.parent = new_node
                 else:
                     new_child_node = cn
                 new_child_nodes.append(new_child_node)


### PR DESCRIPTION
```
sql_query = '''
SELECT *
FROM blobs 
WHERE timestamp > 10
'''
```

```
def _remove_where(node):
  if isinstance(node, exp.Where):
    return None
  return node
```
The  _remove_where transformation to the above sql query was not getting applied because of minor bug in the transform function in the sqlglot. I encountered this error while experimenting with AiDB.
 
```
tokens = Tokenizer().tokenize(sql_query)
expression = Parser().parse(tokens)[0]
print(expression.transform(_remove_where).sql())
```