### PR TITLE
add set function in expression

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ version = (
 
 setup(
     name="sqlglot-aidb",
-    version="0.0.9",
+    version="0.0.10",
     description="An easily customizable SQL parser and transpiler",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -130,7 +130,7 @@ class Expression:
         if hasattr(value, "parent"):
             value.parent = self
             value.arg_key = arg_key
-        elif type(value) is list:
+        elif isinstance(value, list):
             for v in value:
                 if hasattr(v, "parent"):
                     v.parent = self

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -111,6 +111,31 @@ class Expression:
         else:
             yield from self.dfs(self.parent, None)
 
+    def set(self, arg_key: str, value) -> None:
+        """
+        Sets arg_key to value.
+
+        Args:
+            arg_key: name of the expression arg.
+            value: value to set the arg to.
+        """
+        if value is None:
+            self.args.pop(arg_key, None)
+            return
+
+        self.args[arg_key] = value
+        self._set_parent(arg_key, value)
+
+    def _set_parent(self, arg_key: str, value) -> None:
+        if hasattr(value, "parent"):
+            value.parent = self
+            value.arg_key = arg_key
+        elif type(value) is list:
+            for v in value:
+                if hasattr(v, "parent"):
+                    v.parent = self
+                    v.arg_key = arg_key
+
     def dfs(self, parent, key):
         """
         Returns a generator object which visits all nodes in this tree in

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -261,3 +261,14 @@ class TestExpressions(unittest.TestCase):
             expression.sql(),
             "SELECT new_x, new_y FROM table1"
         )
+
+        sql_str3 = '''SELECT x, y FROM table1'''
+        expression = parse_one(sql_str3)
+        new_select = []
+        new_select.append(exp.Column(this=exp.Identifier(this='replaced_col1', quoted=False)))
+        new_select.append(exp.Column(this=exp.Identifier(this='replaced_col2', quoted=False)))
+        expression.set('expressions', new_select)
+        self.assertEqual(
+            expression.sql(),
+            "SELECT replaced_col1, replaced_col2 FROM table1"
+        )

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -235,3 +235,29 @@ class TestExpressions(unittest.TestCase):
         self.assertEqual(parse_one("select *").text("this"), "")
         self.assertEqual(parse_one("1 + 1").text("this"), "1")
         self.assertEqual(parse_one("'a'").text("this"), "a")
+
+    def test_set(self):
+        sql_str1 = '''SELECT x, y FROM table1'''
+        expression = parse_one(sql_str1)
+        for node, _, _ in expression.walk():
+            if isinstance(node, exp.Column):
+                node.set('table', 'table1')
+            if isinstance(node, exp.Expression) and not isinstance(node, exp.Select):
+                assert node.parent is not None
+        self.assertEqual(
+            expression.sql(),
+            "SELECT table1.x, table1.y FROM table1"
+        )
+
+        sql_str2 = '''SELECT x, y FROM table1'''
+        expression = parse_one(sql_str2)
+        for node, _, _ in expression.walk():
+            if isinstance(node, exp.Column):
+                node.args['this'].set('this', f"new_{node.args['this'].args['this']}")
+            if isinstance(node, exp.Expression) and not isinstance(node, exp.Select):
+                assert node.parent is not None
+
+        self.assertEqual(
+            expression.sql(),
+            "SELECT new_x, new_y FROM table1"
+        )


### PR DESCRIPTION
Fix the problem that directly set attribute can't maintain the parent-child relationship in expression tree. Reference: https://github.com/tobymao/sqlglot/blob/7840393b3ad9c54ec6fed66b522f0f3f8e0edbf3/sqlglot/expressions.py#L298-L321